### PR TITLE
Fix environment variables for Supabase functions

### DIFF
--- a/netlify/functions/confirmar-presente.js
+++ b/netlify/functions/confirmar-presente.js
@@ -1,8 +1,9 @@
 const { createClient } = require('@supabase/supabase-js');
 
+// Use the same environment variables defined in netlify.toml and .env
 const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_ANON_KEY
 );
 
 exports.handler = async function (event) {

--- a/netlify/functions/diminuir-cota.js
+++ b/netlify/functions/diminuir-cota.js
@@ -1,9 +1,10 @@
 const { createClient } = require('@supabase/supabase-js');
 
 // Use variáveis de ambiente com os nomes corretos definidos no Netlify
+// Use the same environment variables defined in netlify.toml and .env
 const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_ANON_KEY
 );
 
 exports.handler = async (event) => {


### PR DESCRIPTION
## Summary
- update `confirmar-presente` and `diminuir-cota` to use `SUPABASE_URL` and `SUPABASE_ANON_KEY`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685ab9bda48c8326bbd1a666ce076f83