### PR TITLE
Fix write error in serverless functions

### DIFF
--- a/netlify/functions/confirmar-presente.js
+++ b/netlify/functions/confirmar-presente.js
@@ -1,8 +1,9 @@
 const fs = require('fs');
 const path = require('path');
+const { getWritablePath } = require('./lib/fileHelper');
 
-const file = path.resolve(__dirname, '..', '..', 'controle-de-produto');
-const mensagensFile = path.resolve(__dirname, '..', '..', 'mensagens.json');
+const file = getWritablePath('controle-de-produto');
+const mensagensFile = getWritablePath('mensagens.json');
 
 function carregarProdutos() {
   return JSON.parse(fs.readFileSync(file, 'utf8'));

--- a/netlify/functions/diminuir-cota.js
+++ b/netlify/functions/diminuir-cota.js
@@ -1,7 +1,8 @@
 const fs = require('fs');
 const path = require('path');
+const { getWritablePath } = require('./lib/fileHelper');
 
-const file = path.resolve(__dirname, '..', '..', 'controle-de-produto');
+const file = getWritablePath('controle-de-produto');
 
 function carregarProdutos() {
   return JSON.parse(fs.readFileSync(file, 'utf8'));

--- a/netlify/functions/lib/fileHelper.js
+++ b/netlify/functions/lib/fileHelper.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Returns a writable path for a given filename.
+ * If the default repo path is read-only (common in serverless environments),
+ * the file is copied to /tmp on first use and that path is returned instead.
+ */
+function getWritablePath(filename) {
+  const repoPath = path.resolve(__dirname, '..', '..', filename);
+  const tmpPath = path.join('/tmp', filename);
+
+  try {
+    fs.accessSync(repoPath, fs.constants.W_OK);
+    return repoPath;
+  } catch {
+    if (!fs.existsSync(tmpPath)) {
+      fs.copyFileSync(repoPath, tmpPath);
+    }
+    return tmpPath;
+  }
+}
+
+module.exports = { getWritablePath };

--- a/netlify/functions/listar-mensagens.js
+++ b/netlify/functions/listar-mensagens.js
@@ -1,7 +1,8 @@
 const fs = require('fs');
 const path = require('path');
+const { getWritablePath } = require('./lib/fileHelper');
 
-const file = path.resolve(__dirname, '..', '..', 'mensagens.json');
+const file = getWritablePath('mensagens.json');
 
 exports.handler = async () => {
   try {

--- a/netlify/functions/listar-produtos.js
+++ b/netlify/functions/listar-produtos.js
@@ -1,10 +1,11 @@
 const fs = require('fs');
 const path = require('path');
+const { getWritablePath } = require('./lib/fileHelper');
 
 // Retorna a lista de produtos do arquivo controle-de-produto
 exports.handler = async () => {
   try {
-    const file = path.resolve(__dirname, '..', '..', 'controle-de-produto');
+    const file = getWritablePath('controle-de-produto');
     const data = JSON.parse(fs.readFileSync(file, 'utf8'));
     return {
       statusCode: 200,

--- a/netlify/functions/registrar-mensagem.js
+++ b/netlify/functions/registrar-mensagem.js
@@ -1,7 +1,8 @@
 const fs = require('fs');
 const path = require('path');
+const { getWritablePath } = require('./lib/fileHelper');
 
-const file = path.resolve(__dirname, '..', '..', 'mensagens.json');
+const file = getWritablePath('mensagens.json');
 
 function carregarMensagens() {
   try {

--- a/netlify/functions/testar-conexao.js
+++ b/netlify/functions/testar-conexao.js
@@ -1,11 +1,11 @@
 const fs = require('fs');
 const path = require('path');
+const { getWritablePath } = require('./lib/fileHelper');
 
 exports.handler = async () => {
   try {
-    const data = JSON.parse(
-      fs.readFileSync(path.resolve(__dirname, '..', '..', 'controle-de-produto'), 'utf8')
-    );
+    const file = getWritablePath('controle-de-produto');
+    const data = JSON.parse(fs.readFileSync(file, 'utf8'));
     return {
       statusCode: 200,
       body: JSON.stringify({ sucesso: true, dados: data.slice(0, 1) }),


### PR DESCRIPTION
## Summary
- add helper to get writable data paths
- use helper across Netlify functions to avoid read-only filesystem errors

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685b132edec8832682d841d0ede73f3b