### PR TITLE
Fix product loading path

### DIFF
--- a/netlify/functions/lib/fileHelper.js
+++ b/netlify/functions/lib/fileHelper.js
@@ -7,7 +7,9 @@ const path = require('path');
  * the file is copied to /tmp on first use and that path is returned instead.
  */
 function getWritablePath(filename) {
-  const repoPath = path.resolve(__dirname, '..', '..', filename);
+  // Navigate three directories up from this file's location to reach the repo root
+  // so that files like "controle-de-produto" at the project root can be accessed
+  const repoPath = path.resolve(__dirname, '..', '..', '..', filename);
   const tmpPath = path.join('/tmp', filename);
 
   try {


### PR DESCRIPTION
## Summary
- correct path resolution for repository root in fileHelper

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685b143afe508326b91d106154557821