### PR TITLE
Fix file path resolution

### DIFF
--- a/netlify/functions/lib/fileHelper.js
+++ b/netlify/functions/lib/fileHelper.js
@@ -7,9 +7,10 @@ const path = require('path');
  * the file is copied to /tmp on first use and that path is returned instead.
  */
 function getWritablePath(filename) {
-  // Navigate three directories up from this file's location to reach the repo root
-  // so that files like "controle-de-produto" at the project root can be accessed
-  const repoPath = path.resolve(__dirname, '..', '..', '..', filename);
+  // Resolve the file relative to the current working directory. When running
+  // locally `process.cwd()` is the repository root. In the serverless runtime
+  // it points to the unpacked function directory where the files are bundled.
+  const repoPath = path.join(process.cwd(), filename);
   const tmpPath = path.join('/tmp', filename);
 
   try {


### PR DESCRIPTION
## Summary
- improve file path resolution for serverless functions

## Testing
- `node -e "const handler=require('./netlify/functions/confirmar-presente.js').handler;handler({httpMethod:'POST',body:JSON.stringify({id:3,nome:'abc',mensagem:'msg'})}).then(r=>console.log(r))"`

------
https://chatgpt.com/codex/tasks/task_e_685b155386048326b2f539f883930383