### PR TITLE
Fix missing mensagens file for Netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,5 +4,6 @@
   node_bundler = "esbuild"
 
 [functions]
-  included_files = ["netlify/functions/**", "controle-de-produto"]
+  # Inclui o arquivo de mensagens usado pelas funções
+  included_files = ["netlify/functions/**", "controle-de-produto", "mensagens.json"]
 


### PR DESCRIPTION
## Summary
- include `mensagens.json` in Netlify function bundle so it's available at runtime

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685c0ba787388326ba723d41142423cf