### PR TITLE
Show restricted messages directly

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,6 +194,9 @@ async function finalizarModal(id, btn) {
           });
         } catch (err) {}
         fecharModal(btn);
+        if (document.getElementById('area-restrita').style.display !== 'none') {
+          carregarMensagens();
+        }
       }
 
     window.addEventListener('DOMContentLoaded', renderizarPresentes);
@@ -210,15 +213,45 @@ async function finalizarModal(id, btn) {
   <input type="password" id="senha-restrita" placeholder="Senha" style="padding:5px" />
   <button onclick="acessarRestrito()">Acessar</button>
 </footer>
+<div id="area-restrita" style="display:none;margin:20px;">
+  <h2>Área Restrita</h2>
+  <div id="mensagens-area"></div>
+</div>
 <script>
+  async function carregarMensagens() {
+    try {
+      const resp = await fetch('/.netlify/functions/listar-mensagens');
+      const dados = resp.ok ? await resp.json() : [];
+      const container = document.getElementById('mensagens-area');
+      if (dados.length === 0) {
+        container.innerHTML = '<p>Nenhuma mensagem registrada.</p>';
+        return;
+      }
+      const grupos = {};
+      dados.forEach(m => {
+        grupos[m.nome] = grupos[m.nome] || [];
+        grupos[m.nome].push(m);
+      });
+      container.innerHTML = Object.entries(grupos).map(([nome, msgs]) => {
+        const itens = msgs.map(x => {
+          const data = x.dataHora ? new Date(x.dataHora).toLocaleString('pt-BR') : '';
+          return `<li><strong>${x.produto}</strong> - R$ ${Number(x.valor).toFixed(2).replace('.', ',')}<br>${data}<br>${x.mensagem}</li>`;
+        }).join('');
+        return `<h3>${nome}</h3><ul>${itens}</ul>`;
+      }).join('');
+    } catch (err) {
+      document.getElementById('mensagens-area').innerHTML = '<p>Erro ao carregar mensagens.</p>';
+    }
+  }
+
   function acessarRestrito() {
     const senha = document.getElementById('senha-restrita').value;
     if (senha === '08072010') {
-      window.location.href = 'area-restrita.html';
+      document.getElementById('area-restrita').style.display = 'block';
+      carregarMensagens();
     } else {
       alert('Senha incorreta');
     }
   }
-</script>
 </body>
 </html>

--- a/indexV2.html
+++ b/indexV2.html
@@ -170,6 +170,9 @@
         if (resp.ok) {
           fecharModal(btn);
           await carregarPresentes();
+          if (document.getElementById('area-restrita').style.display !== 'none') {
+            await carregarMensagens();
+          }
         } else {
           const data = await resp.json();
           alert(data.error || 'Erro ao confirmar');
@@ -197,11 +200,42 @@
   <input type="password" id="senha-restrita" placeholder="Senha" style="padding:5px" />
   <button onclick="acessarRestrito()">Acessar</button>
 </footer>
+<div id="area-restrita" style="display:none;margin:20px;">
+  <h2>Área Restrita</h2>
+  <div id="mensagens-area"></div>
+</div>
 <script>
+  async function carregarMensagens() {
+    try {
+      const resp = await fetch('/.netlify/functions/listar-mensagens');
+      const dados = resp.ok ? await resp.json() : [];
+      const container = document.getElementById('mensagens-area');
+      if (dados.length === 0) {
+        container.innerHTML = '<p>Nenhuma mensagem registrada.</p>';
+        return;
+      }
+      const grupos = {};
+      dados.forEach(m => {
+        grupos[m.nome] = grupos[m.nome] || [];
+        grupos[m.nome].push(m);
+      });
+      container.innerHTML = Object.entries(grupos).map(([nome, msgs]) => {
+        const itens = msgs.map(x => {
+          const data = x.dataHora ? new Date(x.dataHora).toLocaleString('pt-BR') : '';
+          return `<li><strong>${x.produto}</strong> - R$ ${Number(x.valor).toFixed(2).replace('.', ',')}<br>${data}<br>${x.mensagem}</li>`;
+        }).join('');
+        return `<h3>${nome}</h3><ul>${itens}</ul>`;
+      }).join('');
+    } catch (err) {
+      document.getElementById('mensagens-area').innerHTML = '<p>Erro ao carregar mensagens.</p>';
+    }
+  }
+
   function acessarRestrito() {
     const senha = document.getElementById('senha-restrita').value;
     if (senha === '08072010') {
-      window.location.href = 'area-restrita.html';
+      document.getElementById('area-restrita').style.display = 'block';
+      carregarMensagens();
     } else {
       alert('Senha incorreta');
     }


### PR DESCRIPTION
## Summary
- include message list on the main pages
- load data from `listar-mensagens` when password is entered
- refresh list if currently visible after confirming a gift

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685c631049e88326a12ff86184986bf4