### PR TITLE
Implement auto-update for restricted messages

### DIFF
--- a/area-restrita.html
+++ b/area-restrita.html
@@ -38,7 +38,10 @@
         document.getElementById('mensagens').innerHTML = '<p>Erro ao carregar mensagens.</p>';
       }
     }
-    window.addEventListener('DOMContentLoaded', carregarMensagens);
+    window.addEventListener('DOMContentLoaded', () => {
+      carregarMensagens();
+      setInterval(carregarMensagens, 5000);
+    });
   </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -187,14 +187,23 @@ async function finalizarModal(id, btn) {
           return;
         }
         try {
-          await fetch('/.netlify/functions/registrar-mensagem', {
+          const resp = await fetch('/.netlify/functions/registrar-mensagem', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ nome, mensagem: msg, produto: produtos[id].nome, valor: produtos[id].valor })
           });
-        } catch (err) {}
+          if (resp.ok && document.getElementById('area-restrita').style.display !== 'none') {
+            const data = await resp.json();
+            if (data.registro) carregarMensagens();
+          }
+        } catch (err) {
+          if (document.getElementById('area-restrita').style.display !== 'none') {
+            carregarMensagens();
+          }
+        }
         fecharModal(btn);
         if (document.getElementById('area-restrita').style.display !== 'none') {
+          // garantia caso falha na resposta
           carregarMensagens();
         }
       }
@@ -249,6 +258,9 @@ async function finalizarModal(id, btn) {
     if (senha === '08072010') {
       document.getElementById('area-restrita').style.display = 'block';
       carregarMensagens();
+      if (!window._mensagensInterval) {
+        window._mensagensInterval = setInterval(carregarMensagens, 5000);
+      }
     } else {
       alert('Senha incorreta');
     }

--- a/indexV2.html
+++ b/indexV2.html
@@ -171,7 +171,8 @@
           fecharModal(btn);
           await carregarPresentes();
           if (document.getElementById('area-restrita').style.display !== 'none') {
-            await carregarMensagens();
+            const data = await resp.json();
+            if (data.registro) await carregarMensagens();
           }
         } else {
           const data = await resp.json();
@@ -183,6 +184,9 @@
         alert('Erro ao confirmar');
         btn.disabled = false;
         btn.textContent = 'Finalizar';
+        if (document.getElementById('area-restrita').style.display !== 'none') {
+          await carregarMensagens();
+        }
       }
     }
 
@@ -236,6 +240,9 @@
     if (senha === '08072010') {
       document.getElementById('area-restrita').style.display = 'block';
       carregarMensagens();
+      if (!window._mensagensInterval) {
+        window._mensagensInterval = setInterval(carregarMensagens, 5000);
+      }
     } else {
       alert('Senha incorreta');
     }

--- a/netlify/functions/confirmar-presente.js
+++ b/netlify/functions/confirmar-presente.js
@@ -53,18 +53,19 @@ exports.handler = async function (event) {
     salvarProdutos(produtos);
 
     const mensagens = carregarMensagens();
-    mensagens.push({
+    const registro = {
       nome,
       mensagem,
       produto: produto.nome,
       valor: produto.valor,
-      dataHora: new Date().toISOString()
-    });
+      dataHora: new Date().toISOString(),
+    };
+    mensagens.push(registro);
     salvarMensagens(mensagens);
 
     return {
       statusCode: 200,
-      body: JSON.stringify({ success: true, produto })
+      body: JSON.stringify({ success: true, produto, registro })
     };
   } catch (err) {
     return {

--- a/netlify/functions/registrar-mensagem.js
+++ b/netlify/functions/registrar-mensagem.js
@@ -31,16 +31,17 @@ exports.handler = async (event) => {
     }
 
     const mensagens = carregarMensagens();
-    mensagens.push({
+    const registro = {
       nome,
       mensagem,
       produto,
       valor,
-      dataHora: new Date().toISOString()
-    });
+      dataHora: new Date().toISOString(),
+    };
+    mensagens.push(registro);
     salvarMensagens(mensagens);
 
-    return { statusCode: 200, body: JSON.stringify({ sucesso: true }) };
+    return { statusCode: 200, body: JSON.stringify({ sucesso: true, registro }) };
   } catch (err) {
     return { statusCode: 500, body: JSON.stringify({ error: err.message }) };
   }


### PR DESCRIPTION
## Summary
- refresh restricted area periodically
- return recorded message from serverless endpoints
- reload messages after finalizing present

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685c8912aa6c8326ab75dec7b8b30058