### PR TITLE
Integrate Google Sheets API and improve security

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,12 @@ npm install -g netlify-cli  # ou use `npx netlify dev`
 
 O arquivo `controle-de-produto.json` acompanha este repositório e é usado
 pelas funções para ler e atualizar as cotas conforme os presentes são
-confirmados.
+confirmados. Para persistir mensagens e sincronizar a lista de presentes
+com uma planilha do Google Sheets, defina duas variáveis de ambiente:
+
+- `API_URL` com a URL do seu Apps Script (ex.: `https://script.google.com/.../exec`)
+- `SENHA_RESTRITA` com a senha de acesso à área restrita.
+
+Em ambientes de produção (ou ao rodar `netlify dev`) exporte essas variáveis.
+Nos testes automatizados elas podem ser definidas temporariamente antes de
+executar `npm test`.

--- a/area-restrita.html
+++ b/area-restrita.html
@@ -13,11 +13,17 @@
   <h1>Área Restrita</h1>
   <div id="mensagens"></div>
   <script>
-    function solicitarSenha() {
-      if (location.protocol !== 'about:' && typeof window.prompt === 'function') {
-        return prompt('Digite a senha de acesso:');
+    async function solicitarSenha() {
+      if (location.protocol === 'about:') {
+        return true;
       }
-      return '08072010';
+      const resp = await fetch('/.netlify/functions/obter-senha');
+      const senhaCorreta = resp.ok ? (await resp.text()).trim() : '';
+      if (typeof window.prompt === 'function') {
+        const entrada = prompt('Digite a senha de acesso:');
+        return entrada === senhaCorreta;
+      }
+      return true;
     }
 
     async function carregarMensagens() {
@@ -34,20 +40,35 @@
           grupos[m.nome] = grupos[m.nome] || [];
           grupos[m.nome].push(m);
         });
-        container.innerHTML = Object.entries(grupos).map(([nome, msgs]) => {
-          const itens = msgs.map(x => {
-            const data = x.dataHora ? new Date(x.dataHora).toLocaleString('pt-BR') : '';
-            return `<li><strong>${x.produto}</strong> - R$ ${Number(x.valor).toFixed(2).replace('.', ',')}<br>${data}<br>${x.mensagem}</li>`;
-          }).join('');
-          return `<h2>${nome}</h2><ul>${itens}</ul>`;
-        }).join('');
+        container.textContent = '';
+        Object.entries(grupos).forEach(([nome, msgs]) => {
+          const titulo = document.createElement('h2');
+          titulo.textContent = nome;
+          container.appendChild(titulo);
+          const ul = document.createElement('ul');
+          msgs.forEach(x => {
+            const li = document.createElement('li');
+            const strong = document.createElement('strong');
+            strong.textContent = x.produto;
+            li.appendChild(strong);
+            li.appendChild(document.createTextNode(` - R$ ${Number(x.valor).toFixed(2).replace('.', ',')}`));
+            if (x.dataHora) {
+              li.appendChild(document.createElement('br'));
+              li.appendChild(document.createTextNode(new Date(x.dataHora).toLocaleString('pt-BR')));
+            }
+            li.appendChild(document.createElement('br'));
+            li.appendChild(document.createTextNode(x.mensagem));
+            ul.appendChild(li);
+          });
+          container.appendChild(ul);
+        });
       } catch (err) {
         document.getElementById('mensagens').innerHTML = '<p>Erro ao carregar mensagens.</p>';
       }
     }
-    window.addEventListener('DOMContentLoaded', () => {
-      const senha = solicitarSenha();
-      if (senha !== '08072010') {
+    window.addEventListener('DOMContentLoaded', async () => {
+      const ok = await solicitarSenha();
+      if (!ok) {
         document.body.innerHTML = '<h1>Acesso negado</h1>';
         return;
       }

--- a/netlify/functions/atualizar-cota.js
+++ b/netlify/functions/atualizar-cota.js
@@ -1,14 +1,15 @@
-const fs = require('fs');
+const fs = require('fs').promises;
 const { getWritablePath } = require('./lib/fileHelper');
 
 const file = getWritablePath('controle-de-produto.json');
 
-function carregarProdutos() {
-  return JSON.parse(fs.readFileSync(file, 'utf8'));
+async function carregarProdutos() {
+  const data = await fs.readFile(file, 'utf8');
+  return JSON.parse(data);
 }
 
-function salvarProdutos(lista) {
-  fs.writeFileSync(file, JSON.stringify(lista, null, 2));
+async function salvarProdutos(lista) {
+  await fs.writeFile(file, JSON.stringify(lista, null, 2));
 }
 
 exports.handler = async (event) => {
@@ -25,7 +26,7 @@ exports.handler = async (event) => {
       return { statusCode: 400, body: JSON.stringify({ error: 'Dados inválidos' }) };
     }
 
-    const produtos = carregarProdutos();
+    const produtos = await carregarProdutos();
     const produto = produtos.find(p => p.id === id);
 
     if (!produto) {
@@ -38,7 +39,7 @@ exports.handler = async (event) => {
     }
 
     produto.cotas = novaCota;
-    salvarProdutos(produtos);
+    await salvarProdutos(produtos);
 
     return { statusCode: 200, body: JSON.stringify({ sucesso: true, produto }) };
   } catch (err) {

--- a/netlify/functions/diminuir-cota.js
+++ b/netlify/functions/diminuir-cota.js
@@ -1,15 +1,15 @@
-const fs = require('fs');
-const path = require('path');
+const fs = require('fs').promises;
 const { getWritablePath } = require('./lib/fileHelper');
 
 const file = getWritablePath('controle-de-produto.json');
 
-function carregarProdutos() {
-  return JSON.parse(fs.readFileSync(file, 'utf8'));
+async function carregarProdutos() {
+  const data = await fs.readFile(file, 'utf8');
+  return JSON.parse(data);
 }
 
-function salvarProdutos(lista) {
-  fs.writeFileSync(file, JSON.stringify(lista, null, 2));
+async function salvarProdutos(lista) {
+  await fs.writeFile(file, JSON.stringify(lista, null, 2));
 }
 
 exports.handler = async (event) => {
@@ -22,7 +22,7 @@ exports.handler = async (event) => {
 
   try {
     const { id } = JSON.parse(event.body);
-    const produtos = carregarProdutos();
+    const produtos = await carregarProdutos();
     const produto = produtos.find(p => p.id === id);
 
     if (!produto || produto.cotas <= 0) {
@@ -34,7 +34,7 @@ exports.handler = async (event) => {
 
     // Evita valores negativos de cota
     produto.cotas = Math.max(produto.cotas - 1, 0);
-    salvarProdutos(produtos);
+    await salvarProdutos(produtos);
 
     return {
       statusCode: 200,

--- a/netlify/functions/listar-mensagens.js
+++ b/netlify/functions/listar-mensagens.js
@@ -1,12 +1,28 @@
-const fs = require('fs');
-const path = require('path');
+const fs = require('fs').promises;
 const { getWritablePath } = require('./lib/fileHelper');
+const API_URL = process.env.API_URL;
 
 const file = getWritablePath('mensagens.json');
 
 exports.handler = async () => {
   try {
-    const data = fs.existsSync(file) ? JSON.parse(fs.readFileSync(file, 'utf8')) : [];
+    if (API_URL) {
+      try {
+        const resp = await fetch(`${API_URL}?lista=mensagens`);
+        if (resp.ok) {
+          const data = await resp.json();
+          return { statusCode: 200, body: JSON.stringify(data) };
+        }
+      } catch (err) {
+        console.error('Erro ao consultar API:', err);
+      }
+    }
+    let data = [];
+    try {
+      data = JSON.parse(await fs.readFile(file, 'utf8'));
+    } catch {
+      data = [];
+    }
     return { statusCode: 200, body: JSON.stringify(data) };
   } catch (err) {
     return { statusCode: 500, body: JSON.stringify({ error: 'Falha ao ler dados' }) };

--- a/netlify/functions/listar-produtos.js
+++ b/netlify/functions/listar-produtos.js
@@ -1,16 +1,24 @@
-const fs = require('fs');
-const path = require('path');
+const fs = require('fs').promises;
 const { getWritablePath } = require('./lib/fileHelper');
+const API_URL = process.env.API_URL;
 
 // Retorna a lista de produtos do arquivo controle-de-produto.json
 exports.handler = async () => {
   try {
+    if (API_URL) {
+      try {
+        const resp = await fetch(`${API_URL}?lista=produtos`);
+        if (resp.ok) {
+          const data = await resp.json();
+          return { statusCode: 200, body: JSON.stringify(data) };
+        }
+      } catch (err) {
+        console.error('Erro ao consultar API:', err);
+      }
+    }
     const file = getWritablePath('controle-de-produto.json');
-    const data = JSON.parse(fs.readFileSync(file, 'utf8'));
-    return {
-      statusCode: 200,
-      body: JSON.stringify(data),
-    };
+    const data = JSON.parse(await fs.readFile(file, 'utf8'));
+    return { statusCode: 200, body: JSON.stringify(data) };
   } catch (err) {
     console.error('Erro ao ler arquivo:', err);
     return {

--- a/netlify/functions/obter-senha.js
+++ b/netlify/functions/obter-senha.js
@@ -1,0 +1,7 @@
+exports.handler = async () => {
+  const senha = process.env.SENHA_RESTRITA || '';
+  return {
+    statusCode: 200,
+    body: senha
+  };
+};

--- a/netlify/functions/testar-conexao.js
+++ b/netlify/functions/testar-conexao.js
@@ -1,11 +1,10 @@
-const fs = require('fs');
-const path = require('path');
+const fs = require('fs').promises;
 const { getWritablePath } = require('./lib/fileHelper');
 
 exports.handler = async () => {
   try {
     const file = getWritablePath('controle-de-produto.json');
-    const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+    const data = JSON.parse(await fs.readFile(file, 'utf8'));
     return {
       statusCode: 200,
       body: JSON.stringify({ sucesso: true, dados: data.slice(0, 1) }),


### PR DESCRIPTION
## Summary
- sanitize messages in `area-restrita.html`
- read restricted area password from new serverless function `obter-senha`
- switch serverless functions to async file access and optional API fetch
- expose password through environment variable
- document `API_URL` and `SENHA_RESTRITA` in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ecf1244b08326ac7774e05bfa3fe1