### PR TITLE
Use published sheet for products

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,13 @@ npm install -g netlify-cli  # ou use `npx netlify dev`
 O arquivo `controle-de-produto.json` acompanha este repositório e é usado
 pelas funções para ler e atualizar as cotas conforme os presentes são
 confirmados. Para persistir mensagens e sincronizar a lista de presentes
-com uma planilha do Google Sheets, defina duas variáveis de ambiente:
+com uma planilha do Google Sheets, defina duas variáveis de ambiente e
+opcionalmente indique a URL pública da planilha:
 
 - `API_URL` com a URL do seu Apps Script (ex.: `https://script.google.com/.../exec`)
 - `SENHA_RESTRITA` com a senha de acesso à área restrita.
+- `SHEET_CSV_URL` com o link CSV publicado (ex.:
+  `https://docs.google.com/.../pub?output=csv`).
 
 Em ambientes de produção (ou ao rodar `netlify dev`) exporte essas variáveis.
 Nos testes automatizados elas podem ser definidas temporariamente antes de
@@ -60,3 +63,12 @@ node scripts/exportar-csv.js
 
 O arquivo será criado no diretório raiz do projeto e pode ser
 importado em qualquer planilha.
+
+## Importando produtos da planilha
+
+Para atualizar `controle-de-produto.json` com os dados da planilha
+publicada, execute:
+
+```bash
+node scripts/importar-planilha.js
+```

--- a/netlify/functions/listar-produtos.js
+++ b/netlify/functions/listar-produtos.js
@@ -1,6 +1,39 @@
 const fs = require('fs').promises;
 const { getWritablePath } = require('./lib/fileHelper');
 const API_URL = process.env.API_URL;
+const SHEET_CSV_URL = process.env.SHEET_CSV_URL ||
+  'https://docs.google.com/spreadsheets/d/e/2PACX-1vTW2DepGwyOvo4OwnBjdMmVffq_m532i4XielrA_Rs0L1LSNOqO4XLS4AUYKQIPD_O9nskYJ-HpKgeV/pub?output=csv';
+
+function parseCsv(text) {
+  const lines = text.trim().split(/\r?\n/);
+  const headers = lines.shift().split(',');
+  return lines.map(line => {
+    const cols = line.split(',');
+    const obj = {};
+    headers.forEach((h, i) => {
+      let v = cols[i];
+      if (['id', 'valor', 'cotas'].includes(h)) v = Number(v);
+      obj[h] = v;
+    });
+    return obj;
+  });
+}
+
+async function carregarDaPlanilha() {
+  try {
+    const controller = new AbortController();
+    const t = setTimeout(() => controller.abort(), 5000);
+    const resp = await fetch(SHEET_CSV_URL, { signal: controller.signal });
+    clearTimeout(t);
+    if (resp.ok) {
+      const texto = await resp.text();
+      return parseCsv(texto);
+    }
+  } catch (err) {
+    console.error('Erro ao consultar planilha:', err);
+  }
+  return null;
+}
 
 // Retorna a lista de produtos do arquivo controle-de-produto.json
 exports.handler = async () => {
@@ -16,6 +49,12 @@ exports.handler = async () => {
         console.error('Erro ao consultar API:', err);
       }
     }
+
+    const sheet = await carregarDaPlanilha();
+    if (sheet && sheet.length) {
+      return { statusCode: 200, body: JSON.stringify(sheet) };
+    }
+
     const file = getWritablePath('controle-de-produto.json');
     const data = JSON.parse(await fs.readFile(file, 'utf8'));
     return { statusCode: 200, body: JSON.stringify(data) };

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "jest",
-    "start": "netlify dev"
+    "start": "netlify dev",
+    "importar-planilha": "node scripts/importar-planilha.js"
   },
   "repository": {
     "type": "git",

--- a/scripts/importar-planilha.js
+++ b/scripts/importar-planilha.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const path = require('path');
+
+const CSV_URL = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vTW2DepGwyOvo4OwnBjdMmVffq_m532i4XielrA_Rs0L1LSNOqO4XLS4AUYKQIPD_O9nskYJ-HpKgeV/pub?output=csv';
+
+function parseCsv(text) {
+  const lines = text.trim().split(/\r?\n/);
+  const headers = lines.shift().split(',');
+  return lines.map(line => {
+    const cols = line.split(',');
+    const obj = {};
+    headers.forEach((h, i) => {
+      let v = cols[i];
+      if (["id", "valor", "cotas"].includes(h)) v = Number(v);
+      obj[h] = v;
+    });
+    return obj;
+  });
+}
+
+async function main() {
+  const resp = await fetch(CSV_URL);
+  if (!resp.ok) throw new Error(`Erro ao baixar CSV: ${resp.status}`);
+  const csv = await resp.text();
+  const produtos = parseCsv(csv);
+  const file = path.join(__dirname, '..', 'controle-de-produto.json');
+  fs.writeFileSync(file, JSON.stringify(produtos, null, 2));
+  console.log(`Arquivo ${file} atualizado com ${produtos.length} produtos.`);
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- support fetching products from published sheet in `listar-produtos`
- add script to update `controle-de-produto.json` from sheet
- document new `SHEET_CSV_URL` variable and import script
- expose `importar-planilha` in `package.json`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ee49b4e748326b45c5926009aa150