### PR TITLE
Handle products via shared sheet

### DIFF
--- a/netlify/functions/atualizar-cota.js
+++ b/netlify/functions/atualizar-cota.js
@@ -1,15 +1,12 @@
 const fs = require('fs').promises;
-const { getWritablePath } = require('./lib/fileHelper');
-
-const file = getWritablePath('controle-de-produto.json');
+const { obterListaProdutos, salvarListaProdutos } = require('./lib/produtos');
 
 async function carregarProdutos() {
-  const data = await fs.readFile(file, 'utf8');
-  return JSON.parse(data);
+  return await obterListaProdutos();
 }
 
 async function salvarProdutos(lista) {
-  await fs.writeFile(file, JSON.stringify(lista, null, 2));
+  await salvarListaProdutos(lista);
 }
 
 exports.handler = async (event) => {

--- a/netlify/functions/confirmar-presente.js
+++ b/netlify/functions/confirmar-presente.js
@@ -1,17 +1,16 @@
 const fs = require('fs').promises;
 const { getWritablePath } = require('./lib/fileHelper');
+const { obterListaProdutos, salvarListaProdutos } = require('./lib/produtos');
 const API_URL = process.env.API_URL;
 
-const file = getWritablePath('controle-de-produto.json');
 const mensagensFile = getWritablePath('mensagens.json');
 
 async function carregarProdutos() {
-  const data = await fs.readFile(file, 'utf8');
-  return JSON.parse(data);
+  return await obterListaProdutos();
 }
 
 async function salvarProdutos(lista) {
-  await fs.writeFile(file, JSON.stringify(lista, null, 2));
+  await salvarListaProdutos(lista);
 }
 
 async function carregarMensagens() {

--- a/netlify/functions/diminuir-cota.js
+++ b/netlify/functions/diminuir-cota.js
@@ -1,15 +1,12 @@
 const fs = require('fs').promises;
-const { getWritablePath } = require('./lib/fileHelper');
-
-const file = getWritablePath('controle-de-produto.json');
+const { obterListaProdutos, salvarListaProdutos } = require('./lib/produtos');
 
 async function carregarProdutos() {
-  const data = await fs.readFile(file, 'utf8');
-  return JSON.parse(data);
+  return await obterListaProdutos();
 }
 
 async function salvarProdutos(lista) {
-  await fs.writeFile(file, JSON.stringify(lista, null, 2));
+  await salvarListaProdutos(lista);
 }
 
 exports.handler = async (event) => {

--- a/netlify/functions/lib/produtos.js
+++ b/netlify/functions/lib/produtos.js
@@ -1,0 +1,68 @@
+const fs = require('fs').promises;
+const { getWritablePath } = require('./fileHelper');
+const API_URL = process.env.API_URL;
+const SHEET_CSV_URL = process.env.SHEET_CSV_URL ||
+  'https://docs.google.com/spreadsheets/d/e/2PACX-1vTW2DepGwyOvo4OwnBjdMmVffq_m532i4XielrA_Rs0L1LSNOqO4XLS4AUYKQIPD_O9nskYJ-HpKgeV/pub?output=csv';
+
+function parseCsv(text) {
+  const lines = text.trim().split(/\r?\n/);
+  const headers = lines.shift().split(',');
+  return lines.map(line => {
+    const cols = line.split(',');
+    const obj = {};
+    headers.forEach((h, i) => {
+      let v = cols[i];
+      if (['id', 'valor', 'cotas'].includes(h)) v = Number(v);
+      obj[h] = v;
+    });
+    return obj;
+  });
+}
+
+async function carregarDaPlanilha() {
+  try {
+    const controller = new AbortController();
+    const t = setTimeout(() => controller.abort(), 5000);
+    const resp = await fetch(SHEET_CSV_URL, { signal: controller.signal });
+    clearTimeout(t);
+    if (resp.ok) {
+      const texto = await resp.text();
+      return parseCsv(texto);
+    }
+  } catch (err) {
+    console.error('Erro ao consultar planilha:', err);
+  }
+  return null;
+}
+
+async function obterListaProdutos() {
+  if (API_URL) {
+    try {
+      const resp = await fetch(`${API_URL}?lista=produtos`);
+      if (resp.ok) {
+        return await resp.json();
+      }
+    } catch (err) {
+      console.error('Erro ao consultar API:', err);
+    }
+  }
+
+  const sheet = await carregarDaPlanilha();
+  if (sheet && sheet.length) {
+    return sheet;
+  }
+
+  const file = getWritablePath('controle-de-produto.json');
+  const data = await fs.readFile(file, 'utf8');
+  return JSON.parse(data);
+}
+
+async function salvarListaProdutos(lista) {
+  const file = getWritablePath('controle-de-produto.json');
+  await fs.writeFile(file, JSON.stringify(lista, null, 2));
+}
+
+module.exports = {
+  obterListaProdutos,
+  salvarListaProdutos,
+};

--- a/netlify/functions/listar-produtos.js
+++ b/netlify/functions/listar-produtos.js
@@ -1,65 +1,12 @@
-const fs = require('fs').promises;
-const { getWritablePath } = require('./lib/fileHelper');
-const API_URL = process.env.API_URL;
-const SHEET_CSV_URL = process.env.SHEET_CSV_URL ||
-  'https://docs.google.com/spreadsheets/d/e/2PACX-1vTW2DepGwyOvo4OwnBjdMmVffq_m532i4XielrA_Rs0L1LSNOqO4XLS4AUYKQIPD_O9nskYJ-HpKgeV/pub?output=csv';
+const { obterListaProdutos } = require('./lib/produtos');
 
-function parseCsv(text) {
-  const lines = text.trim().split(/\r?\n/);
-  const headers = lines.shift().split(',');
-  return lines.map(line => {
-    const cols = line.split(',');
-    const obj = {};
-    headers.forEach((h, i) => {
-      let v = cols[i];
-      if (['id', 'valor', 'cotas'].includes(h)) v = Number(v);
-      obj[h] = v;
-    });
-    return obj;
-  });
-}
-
-async function carregarDaPlanilha() {
-  try {
-    const controller = new AbortController();
-    const t = setTimeout(() => controller.abort(), 5000);
-    const resp = await fetch(SHEET_CSV_URL, { signal: controller.signal });
-    clearTimeout(t);
-    if (resp.ok) {
-      const texto = await resp.text();
-      return parseCsv(texto);
-    }
-  } catch (err) {
-    console.error('Erro ao consultar planilha:', err);
-  }
-  return null;
-}
-
-// Retorna a lista de produtos do arquivo controle-de-produto.json
+// Retorna a lista de produtos a partir da planilha ou arquivo local
 exports.handler = async () => {
   try {
-    if (API_URL) {
-      try {
-        const resp = await fetch(`${API_URL}?lista=produtos`);
-        if (resp.ok) {
-          const data = await resp.json();
-          return { statusCode: 200, body: JSON.stringify(data) };
-        }
-      } catch (err) {
-        console.error('Erro ao consultar API:', err);
-      }
-    }
-
-    const sheet = await carregarDaPlanilha();
-    if (sheet && sheet.length) {
-      return { statusCode: 200, body: JSON.stringify(sheet) };
-    }
-
-    const file = getWritablePath('controle-de-produto.json');
-    const data = JSON.parse(await fs.readFile(file, 'utf8'));
+    const data = await obterListaProdutos();
     return { statusCode: 200, body: JSON.stringify(data) };
   } catch (err) {
-    console.error('Erro ao ler arquivo:', err);
+    console.error('Erro ao obter produtos:', err);
     return {
       statusCode: 500,
       body: JSON.stringify({ error: 'Falha ao ler dados.' }),

--- a/netlify/functions/testar-conexao.js
+++ b/netlify/functions/testar-conexao.js
@@ -1,10 +1,8 @@
-const fs = require('fs').promises;
-const { getWritablePath } = require('./lib/fileHelper');
+const { obterListaProdutos } = require('./lib/produtos');
 
 exports.handler = async () => {
   try {
-    const file = getWritablePath('controle-de-produto.json');
-    const data = JSON.parse(await fs.readFile(file, 'utf8'));
+    const data = await obterListaProdutos();
     return {
       statusCode: 200,
       body: JSON.stringify({ sucesso: true, dados: data.slice(0, 1) }),


### PR DESCRIPTION
## Summary
- centralize product loading in a new helper that reads from the published sheet or local JSON
- update all functions to use the new helper
- revert temp file handling in `fileHelper`

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685eea1278788326b8be81ebb6b7c63e