### PR TITLE
Integrate sheet-only messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ As funções obtêm os produtos diretamente de uma planilha no Google Sheets.
 Caso deseje trabalhar offline é possível gerar um arquivo `controle-de-produto.json`
 executando `npm run importar-planilha`. Para persistir mensagens e sincronizar a
 lista de presentes com a planilha, defina duas variáveis de ambiente e, opcionalmente,
-indique a URL pública do CSV:
+indique a URL pública do CSV. Quando `API_URL` estiver configurada as mensagens
+serão registradas **exclusivamente** na aba **Mensagens** da planilha:
 
 - `API_URL` com a URL do seu Apps Script (ex.: `https://script.google.com/.../exec`)
 - `SENHA_RESTRITA` com a senha de acesso à área restrita.

--- a/netlify/functions/confirmar-presente.js
+++ b/netlify/functions/confirmar-presente.js
@@ -54,7 +54,6 @@ exports.handler = async function (event) {
     produto.cotas = Math.max(produto.cotas - 1, 0);
     await salvarProdutos(produtos);
 
-    const mensagens = await carregarMensagens();
     const registro = {
       nome,
       mensagem,
@@ -62,17 +61,20 @@ exports.handler = async function (event) {
       valor: produto.valor,
       dataHora: new Date().toISOString(),
     };
-    mensagens.push(registro);
-    await salvarMensagens(mensagens);
+
     if (API_URL) {
       const envio = { ...registro };
       envio['data hora'] = envio.dataHora;
       delete envio.dataHora;
-      fetch(API_URL, {
+      await fetch(API_URL, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(envio)
-      }).catch(() => {});
+      });
+    } else {
+      const mensagens = await carregarMensagens();
+      mensagens.push(registro);
+      await salvarMensagens(mensagens);
     }
 
     return {

--- a/netlify/functions/registrar-mensagem.js
+++ b/netlify/functions/registrar-mensagem.js
@@ -31,7 +31,6 @@ exports.handler = async (event) => {
       return { statusCode: 400, body: JSON.stringify({ error: 'Dados inválidos' }) };
     }
 
-    const mensagens = await carregarMensagens();
     const registro = {
       nome,
       mensagem,
@@ -39,17 +38,20 @@ exports.handler = async (event) => {
       valor,
       dataHora: new Date().toISOString(),
     };
-    mensagens.push(registro);
-    await salvarMensagens(mensagens);
+
     if (API_URL) {
       const envio = { ...registro };
       envio['data hora'] = envio.dataHora;
       delete envio.dataHora;
-      fetch(API_URL, {
+      await fetch(API_URL, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(envio)
-      }).catch(() => {});
+      });
+    } else {
+      const mensagens = await carregarMensagens();
+      mensagens.push(registro);
+      await salvarMensagens(mensagens);
     }
 
     return { statusCode: 200, body: JSON.stringify({ sucesso: true, registro }) };


### PR DESCRIPTION
## Summary
- ensure messages go exclusively to the spreadsheet when `API_URL` is configured
- clarify behaviour in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685eed99a58483269c6a894138ed3b97