### PR TITLE
Fix planilha access without local json

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,16 +37,19 @@ npm install -g netlify-cli  # ou use `npx netlify dev`
    ```
 
 As funções obtêm os produtos diretamente de uma planilha no Google Sheets.
-Caso deseje trabalhar offline é possível gerar um arquivo `controle-de-produto.json`
-executando `npm run importar-planilha`. Para persistir mensagens e sincronizar a
-lista de presentes com a planilha, defina duas variáveis de ambiente e, opcionalmente,
-indique a URL pública do CSV. Quando `API_URL` estiver configurada as mensagens
-serão registradas **exclusivamente** na aba **Mensagens** da planilha:
+A URL do Apps Script que expõe esses dados já está configurada por padrão no
+código das funções, portanto normalmente não é necessário definir `API_URL` em
+ambientes de produção. Caso deseje trabalhar offline é possível gerar um arquivo
+`controle-de-produto.json` executando `npm run importar-planilha`. Para
+persistir mensagens e sincronizar a lista de presentes com a planilha, defina
+duas variáveis de ambiente e, opcionalmente, indique a URL pública do CSV.
+Quando `API_URL` estiver configurada as mensagens serão registradas
+**exclusivamente** na aba **Mensagens** da planilha:
 
 - `API_URL` com a URL do seu Apps Script (ex.: `https://script.google.com/.../exec`)
 - `SENHA_RESTRITA` com a senha de acesso à área restrita.
 - `SHEET_CSV_URL` com o link CSV publicado (ex.:
-  `https://docs.google.com/.../pub?output=csv`).
+  `https://script.google.com/.../exec?lista=produtos&format=csv`).
 
 Em ambientes de produção (ou ao rodar `netlify dev`) exporte essas variáveis.
 Nos testes automatizados elas podem ser definidas temporariamente antes de

--- a/netlify/functions/lib/fileHelper.js
+++ b/netlify/functions/lib/fileHelper.js
@@ -18,7 +18,11 @@ function getWritablePath(filename) {
     return repoPath;
   } catch {
     if (!fs.existsSync(tmpPath)) {
-      fs.copyFileSync(repoPath, tmpPath);
+      if (fs.existsSync(repoPath)) {
+        fs.copyFileSync(repoPath, tmpPath);
+      } else {
+        fs.writeFileSync(tmpPath, '');
+      }
     }
     return tmpPath;
   }


### PR DESCRIPTION
## Summary
- prevent fileHelper from failing when the source file is missing
- load product list from the shared spreadsheet by default
- fallback to local file only when running tests or on error
- allow saving product list via the Apps Script when available
- document default Apps Script URL

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685eef717f3c8326b7639edc0ec3a706