### PR TITLE
Atualiza data em horario de Brasil

### DIFF
--- a/area-restrita.html
+++ b/area-restrita.html
@@ -54,7 +54,9 @@
             li.appendChild(document.createTextNode(` - R$ ${Number(x.valor).toFixed(2).replace('.', ',')}`));
             if (x.dataHora) {
               li.appendChild(document.createElement('br'));
-              li.appendChild(document.createTextNode(new Date(x.dataHora).toLocaleString('pt-BR')));
+              li.appendChild(document.createTextNode(
+                new Date(x.dataHora).toLocaleString('pt-BR', { timeZone: 'America/Sao_Paulo' })
+              ));
             }
             li.appendChild(document.createElement('br'));
             li.appendChild(document.createTextNode(x.mensagem));

--- a/netlify/functions/confirmar-presente.js
+++ b/netlify/functions/confirmar-presente.js
@@ -54,12 +54,14 @@ exports.handler = async function (event) {
     produto.cotas = Math.max(produto.cotas - 1, 0);
     await salvarProdutos(produtos);
 
+    const brDate = new Date().toLocaleString('sv-SE', { timeZone: 'America/Sao_Paulo' })
+      .replace(' ', 'T') + '-03:00';
     const registro = {
       nome,
       mensagem,
       produto: produto.nome,
       valor: produto.valor,
-      dataHora: new Date().toISOString(),
+      dataHora: brDate,
     };
 
     if (API_URL) {

--- a/netlify/functions/registrar-mensagem.js
+++ b/netlify/functions/registrar-mensagem.js
@@ -31,12 +31,14 @@ exports.handler = async (event) => {
       return { statusCode: 400, body: JSON.stringify({ error: 'Dados inválidos' }) };
     }
 
+    const brDate = new Date().toLocaleString('sv-SE', { timeZone: 'America/Sao_Paulo' })
+      .replace(' ', 'T') + '-03:00';
     const registro = {
       nome,
       mensagem,
       produto,
       valor,
-      dataHora: new Date().toISOString(),
+      dataHora: brDate,
     };
 
     if (API_URL) {

--- a/tests/functions.test.js
+++ b/tests/functions.test.js
@@ -98,7 +98,9 @@ test('dados aparecem na area restrita', async () => {
   dom.window.setInterval = () => {};
   await dom.window.carregarMensagens();
   const text = dom.window.document.getElementById('mensagens').textContent;
-  const dataStr = new Date(ultima.dataHora).toLocaleString('pt-BR');
+  const dataStr = new Date(ultima.dataHora).toLocaleString('pt-BR', {
+    timeZone: 'America/Sao_Paulo',
+  });
   expect(text).toContain(nome);
   expect(text).toContain(produto.nome);
   expect(text).toContain(produto.valor.toFixed(2).replace('.', ','));


### PR DESCRIPTION
## Summary
- record timestamp in BRT for registrar-mensagem and confirmar-presente
- exibit messages using Brazil timezone
- adjust test expecting timezone

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685ef863444083269ed1b6a416f353c8