### PR TITLE
Fix purchase info saving

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,7 +194,7 @@ async function finalizarModal(id, btn) {
           const resp = await fetch('/.netlify/functions/confirmar-presente', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ id, nome, mensagem: msg })
+            body: JSON.stringify({ id, nome, mensagem: msg, produto: produto.nome, valor: produto.valor })
           });
           if (resp.ok) {
             await resp.json();


### PR DESCRIPTION
## Summary
- support passing product info directly to `confirmar-presente`
- include product info when calling the function from the frontend

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685f0ad754108326ab2a6a4d8a0f09e9